### PR TITLE
Before major release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": "^7.0",
         "bigcommerce/injector": "@stable",
         "phpunit/phpunit": "^6.0"
     },

--- a/src/AutoMockingTest.php
+++ b/src/AutoMockingTest.php
@@ -30,19 +30,6 @@ abstract class AutoMockingTest extends TestCase
      * @param string $className The FQCN of the class we are creating
      * @param array $parameters Any parameters to pass to the constructor. Can be keyed by type, name or position.
      * @return object
-     * @deprecated
-     * @see createWithMocks()
-     */
-    protected function autoMock($className, $parameters = [])
-    {
-        return $this->injector->create($className, $parameters);
-    }
-
-    /**
-     * Create an instance of $className and automatically mock all its constructor dependencies.
-     * @param string $className The FQCN of the class we are creating
-     * @param array $parameters Any parameters to pass to the constructor. Can be keyed by type, name or position.
-     * @return object
      */
     protected function createWithMocks($className, $parameters = [])
     {


### PR DESCRIPTION
#### What?
- Require PHP 7.0 because PHPUnit 6 (which is currently required in `master`) requires it
- Remove deprecated method AutoMockingTest::autoMock()

#### Tickets / Documentation
n/a