### PR TITLE
Risky Tests Handling: Test shouldn't be marked as Risky when it has Prophecy predictions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
  - composer install
 
 script:
- - vendor/bin/phpunit
+ - vendor/bin/phpunit --exclude-group=dummy

--- a/src/AutoMockingTest.php
+++ b/src/AutoMockingTest.php
@@ -3,6 +3,8 @@ namespace Bigcommerce\MockInjector;
 
 use Bigcommerce\Injector\InjectorInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\MethodProphecy;
+use Prophecy\Prophet;
 
 /**
  * Configured PHPUnit TestCase providing auto-mocking of dependency injection components using the
@@ -15,6 +17,9 @@ abstract class AutoMockingTest extends TestCase
     /** @var InjectorInterface|MockInjector */
     protected $injector;
 
+    /** @var Prophet */
+    private $prophet;
+
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
@@ -22,7 +27,8 @@ abstract class AutoMockingTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->injector = new MockInjector();
+        $this->prophet = new Prophet();
+        $this->injector = new MockInjector(new ProphecyMockingContainer($this->prophet));
     }
 
     /**
@@ -44,5 +50,14 @@ abstract class AutoMockingTest extends TestCase
     {
         parent::tearDown();
         $this->injector->checkPredictions();
+
+        foreach ($this->prophet->getProphecies() as $objectProphecy) {
+            foreach ($objectProphecy->getMethodProphecies() as $methodProphecies) {
+                /** @var MethodProphecy[] $methodProphecies */
+                foreach ($methodProphecies as $methodProphecy) {
+                    $this->addToAssertionCount(count($methodProphecy->getCheckedPredictions()));
+                }
+            }
+        }
     }
 }

--- a/src/AutoMockingTest.php
+++ b/src/AutoMockingTest.php
@@ -18,7 +18,7 @@ abstract class AutoMockingTest extends TestCase
     protected $injector;
 
     /** @var Prophet */
-    private $prophet;
+    private $mockingContainerProphet;
 
     /**
      * Sets up the fixture, for example, open a network connection.
@@ -27,8 +27,8 @@ abstract class AutoMockingTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->prophet = new Prophet();
-        $this->injector = new MockInjector(new ProphecyMockingContainer($this->prophet));
+        $this->mockingContainerProphet = new Prophet();
+        $this->injector = new MockInjector(new ProphecyMockingContainer($this->mockingContainerProphet));
     }
 
     /**
@@ -51,7 +51,7 @@ abstract class AutoMockingTest extends TestCase
         parent::tearDown();
         $this->injector->checkPredictions();
 
-        foreach ($this->prophet->getProphecies() as $objectProphecy) {
+        foreach ($this->mockingContainerProphet->getProphecies() as $objectProphecy) {
             foreach ($objectProphecy->getMethodProphecies() as $methodProphecies) {
                 /** @var MethodProphecy[] $methodProphecies */
                 foreach ($methodProphecies as $methodProphecy) {

--- a/tests/AutoMockingTestTest.php
+++ b/tests/AutoMockingTestTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types = 1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Tests\Dummy\DummyTest;
+
+class AutoMockingTestTest extends TestCase
+{
+    public function testTestShouldNotBeRiskyWhenItHasProphecyExpectations()
+    {
+        $riskyTest = new DummyTest('testWithProphecyExpectations');
+
+        $riskyTest->runBare();
+
+        $this->assertSame(1, $riskyTest->getNumAssertions());
+    }
+
+    public function testTestShouldBeRiskyWhenItHasNoAssertions()
+    {
+        $riskyTest = new DummyTest('testWithoutAssertions');
+
+        $riskyTest->runBare();
+
+        $this->assertSame(0, $riskyTest->getNumAssertions());
+    }
+}

--- a/tests/Dummy/DummyTest.php
+++ b/tests/Dummy/DummyTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types = 1);
+
+namespace Tests\Dummy;
+
+use Bigcommerce\MockInjector\AutoMockingTest;
+use Prophecy\Prophecy\ObjectProphecy;
+
+/**
+ * @group dummy
+ */
+class DummyTest extends AutoMockingTest
+{
+    /**
+     * This is a dummy test which is called by AutoMockInjectorTestTest. It has one expectation configured using
+     * Prophecy (see `->shouldBeCalled()`), therefore there is 1 assertion and the test shouldn't be marked as Risky.
+     */
+    public function testWithProphecyExpectations()
+    {
+        /** @var DummyDependency $dummyDependency */
+        $dummyDependency = $this->createWithMocks(DummyDependency::class);
+
+        /** @var DummySubDependency|ObjectProphecy $subDependency */
+        $subDependency = $this->injector->getProphecy(DummySubDependency::class);
+        $subDependency->setEnabled(true)->shouldBeCalled();
+
+        $dummyDependency->getDependency()->setEnabled(true);
+    }
+
+    /**
+     * This is a dummy test which doesn't have any assertions, therefore is risky.
+     */
+    public function testWithoutAssertions()
+    {
+    }
+}


### PR DESCRIPTION
#### What?

Test shouldn't be marked as Risky when it has Prophecy predictions

#### Tickets / Documentation

n/a
