### PR TITLE
add phpspec/prophecy-phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "bigcommerce/injector": "^2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0"
+        "phpunit/phpunit": "^9.0",
+        "phpspec/prophecy-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "778c83dbdc438053e0ec3adad62f431e",
+    "content-hash": "8dd270d193849446d01b45ee18810631",
     "packages": [
         {
             "name": "bigcommerce/injector",
@@ -870,6 +870,54 @@
                 "stub"
             ],
             "time": "2020-09-29T09:10:42+00:00"
+        },
+        {
+            "name": "phpspec/prophecy-phpunit",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy-phpunit.git",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8",
+                "phpspec/prophecy": "^1.3",
+                "phpunit/phpunit": "^9.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\PhpUnit\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                }
+            ],
+            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
+            "homepage": "http://phpspec.net",
+            "keywords": [
+                "phpunit",
+                "prophecy"
+            ],
+            "time": "2020-07-09T08:33:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         convertWarningsToExceptions="true"
+         failOnWarning="true"
+         failOnRisky="true"
 >
-    <testsuites>
-        <testsuite name="MockInjector Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="MockInjector Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <groups>
+    <exclude>
+      <group>dummy</group>
+    </exclude>
+  </groups>
 </phpunit>

--- a/src/AutoMockingTest.php
+++ b/src/AutoMockingTest.php
@@ -3,6 +3,7 @@ namespace Bigcommerce\MockInjector;
 
 use Bigcommerce\Injector\InjectorInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\MethodProphecy;
 use Prophecy\Prophet;
 
@@ -14,6 +15,8 @@ use Prophecy\Prophet;
  */
 abstract class AutoMockingTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var InjectorInterface|MockInjector */
     protected $injector;
 

--- a/src/ProphecyMockingContainer.php
+++ b/src/ProphecyMockingContainer.php
@@ -3,11 +3,14 @@
 namespace Bigcommerce\MockInjector;
 
 use Prophecy\Exception\Prediction\AggregateException;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophet;
 
 class ProphecyMockingContainer implements MockingContainerInterface
 {
+    use ProphecyTrait;
+
     /**
      * @var Prophet
      */

--- a/tests/MockInjectorTest.php
+++ b/tests/MockInjectorTest.php
@@ -2,6 +2,7 @@
 namespace Tests;
 
 use Bigcommerce\Injector\InjectorInterface;
+use Bigcommerce\MockInjector\AutoMockingTest;
 use Bigcommerce\MockInjector\MockInjector;
 use Bigcommerce\MockInjector\ProphecyMockingContainer;
 use PHPUnit\Framework\TestCase;
@@ -12,18 +13,18 @@ use Tests\Dummy\DummySubDependency;
 /**
  * @coversDefaultClass \Bigcommerce\MockInjector\MockInjector
  */
-class MockInjectorTest extends TestCase
+class MockInjectorTest extends AutoMockingTest
 {
     /** @var  ObjectProphecy|ProphecyMockingContainer */
     private $mockContainer;
     /** @var  ObjectProphecy|InjectorInterface */
-    private $injector;
+    private $mockInjector;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->mockContainer = $this->prophesize(ProphecyMockingContainer::class);
-        $this->injector = $this->prophesize(InjectorInterface::class);
+        $this->mockInjector = $this->prophesize(InjectorInterface::class);
     }
 
     /**
@@ -31,8 +32,8 @@ class MockInjectorTest extends TestCase
      */
     public function testCreate()
     {
-        $this->injector->create("abc123", [1 => "hello"])->willReturn("cat")->shouldBeCalledTimes(1);
-        $i = new MockInjector($this->mockContainer->reveal(), $this->injector->reveal());
+        $this->mockInjector->create("abc123", [1 => "hello"])->willReturn("cat")->shouldBeCalledTimes(1);
+        $i = new MockInjector($this->mockContainer->reveal(), $this->mockInjector->reveal());
         $this->assertEquals("cat", $i->create("abc123", [1 => "hello"]));
     }
 
@@ -42,8 +43,8 @@ class MockInjectorTest extends TestCase
     public function testInvoke()
     {
         $obj = new \stdClass();
-        $this->injector->invoke($obj, "method1", [1 => "hello"])->willReturn("fish")->shouldBeCalledTimes(1);
-        $i = new MockInjector($this->mockContainer->reveal(), $this->injector->reveal());
+        $this->mockInjector->invoke($obj, "method1", [1 => "hello"])->willReturn("fish")->shouldBeCalledTimes(1);
+        $i = new MockInjector($this->mockContainer->reveal(), $this->mockInjector->reveal());
         $this->assertEquals("fish", $i->invoke($obj, "method1", [1 => "hello"]));
     }
 
@@ -53,7 +54,7 @@ class MockInjectorTest extends TestCase
     public function testCheckPredictions()
     {
         $this->mockContainer->checkPredictions()->shouldBeCalledTimes(1);
-        $i = new MockInjector($this->mockContainer->reveal(), $this->injector->reveal());
+        $i = new MockInjector($this->mockContainer->reveal(), $this->mockInjector->reveal());
         $i->checkPredictions();
     }
 
@@ -63,7 +64,7 @@ class MockInjectorTest extends TestCase
     public function testGetAllMocks()
     {
         $this->mockContainer->getAllMocks()->willReturn([1, 2, 6])->shouldBeCalledTimes(1);
-        $i = new MockInjector($this->mockContainer->reveal(), $this->injector->reveal());
+        $i = new MockInjector($this->mockContainer->reveal(), $this->mockInjector->reveal());
         $this->assertEquals([1, 2, 6], $i->getAllMocks());
     }
 
@@ -74,7 +75,7 @@ class MockInjectorTest extends TestCase
     {
         $dummy = new \stdClass();
         $this->mockContainer->getMock("blah")->willReturn($dummy)->shouldBeCalledTimes(1);
-        $i = new MockInjector($this->mockContainer->reveal(), $this->injector->reveal());
+        $i = new MockInjector($this->mockContainer->reveal(), $this->mockInjector->reveal());
         $this->assertEquals($dummy, $i->getMock("blah"));
     }
 


### PR DESCRIPTION
#### What?

- add `phpspec/prophecy-phpunit` package. This will fix deprecation warnings with `phpunit` 9.
- add `convertWarningsToExceptions` and `failOnWarning` attributes.
- change `phpunit.xml` with `--migrate-configuration` command.
